### PR TITLE
feat(db): add schema and registry foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,22 @@ jobs:
             --ignore=tests/test_cli_basics_extra.py \
             --cov=src --cov-report=term-missing --cov-fail-under=0
 
+  schemas:
+    name: Schema compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run schema compatibility checks
+        run: |
+          python scripts/check_schema_compatibility.py
+
   extended:
     name: Extended tests (best-effort)
     runs-on: ubuntu-latest

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -1,0 +1,18 @@
+Backup and Restore Strategy
+
+- Scope: registry database (SQLite by default; Postgres supported via external tools).
+- Backup cadence: on-demand with retention policy guidance below.
+
+Implementation
+- Scripts: `scripts/backup_database.sh|.ps1` and `scripts/restore_database.sh|.ps1`.
+- Environment: `DATABASE_URL`. Defaults to `sqlite:///.data/registry.db`.
+- SQLite: Python-based file copy (consistent when DB is not in use).
+- Postgres: use `pg_dump`/`pg_restore` (not bundled); integrate in CI/CD as needed.
+
+Retention Policy
+- Local: keep last 30 daily backups in `.backups/`.
+- Remote: optionally upload backups to S3/Azure Blob for 90 days.
+
+Validation
+- Periodic restore tests into a scratch database, verifying core tables and recent records are present.
+

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,20 @@
+Disaster Recovery Plan
+
+Objectives
+- RTO: <= 2 hours for registry database.
+- RPO: <= 15 minutes (based on backup cadence and WAL/archive policy for Postgres; N/A for SQLite).
+
+Procedures
+- Declare incident, assign incident lead, notify stakeholders.
+- Retrieve latest valid backup from local `.backups/` or remote storage.
+- Provision replacement database (SQLite file or Postgres instance).
+- Run restore procedure and smoke validation.
+- Re-point orchestrator `DATABASE_URL` and resume operations.
+
+Escalation & Contacts
+- Primary: Core maintainers
+- Secondary: Platform/Infra on-call
+
+Drills
+- Run a quarterly tabletop and one full restore exercise.
+

--- a/docs/sla-targets.md
+++ b/docs/sla-targets.md
@@ -1,0 +1,7 @@
+SLA Targets (Registry Database)
+
+- RTO: 2 hours
+- RPO: 15 minutes
+- Availability: 99.9%
+- Backup retention: 30d local, 90d remote
+


### PR DESCRIPTION
Implements workstream 04 (Database):

- Alembic initialized with baseline + workstream registry migrations
- SQLAlchemy models + connection helpers and registry API (CRUD, filters)
- Tests: migrations, registry lifecycle, backup/restore, schema-compat
- Schema versioning gate added to CI via scripts/check_schema_compatibility.py
- Backup/restore scripts + DR and SLA docs

Validation:
- Migration upgrade/downgrade tested (SQLite, env-driven URL)
- CRUD + status transitions + query filters covered
- Schema compatibility detects required-field removal/type change
- Default DATABASE_URL: sqlite:///.data/registry.db (override for Postgres)

CI:
- Added schema compatibility job to .github/workflows/ci.yml

Closes: foundation for state management and registry.