### PR TITLE
chore(ci): harden security and improve CI pipeline

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Conventional Commits format enforcement
+# Allowed: <type>(<scope>)?: <subject>
+# Types: feat, fix, chore, docs, style, refactor, perf, test, ci, build, revert
+
+message_file="$1"
+message=$(head -n1 "$message_file" | tr -d '\r')
+
+conventional_regex='^(feat|fix|chore|docs|style|refactor|perf|test|ci|build|revert)(\([a-z0-9_.-]+\))?: .+'
+
+if [[ "$message" =~ $conventional_regex ]]; then
+  exit 0
+fi
+
+echo "Commit message does not follow Conventional Commits." >&2
+echo "Example: feat(parser): add new option" >&2
+exit 1
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     labels: ["dependencies"]
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -13,3 +16,13 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     labels: ["dependencies"]
+
+  - package-ecosystem: "npm"
+    directory: "/vscode-extension"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,56 @@ jobs:
           PYTHONPATH: src
         run: |
           pytest -q tests --cov=src --cov-report=term-missing --maxfail=1
+
+  security:
+    name: Security (Bandit + Safety)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-sec-${{ hashFiles('**/pyproject.toml', '**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-sec-
+
+      - name: Install security tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit safety
+
+      - name: Run Bandit (SAST)
+        run: |
+          bandit -r src -x tests -f sarif -o bandit.sarif -lll
+
+      - name: Upload Bandit SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: bandit.sarif
+
+      - name: Run Safety (SCA)
+        run: |
+          if [ -f requirements.txt ]; then REQS="-r requirements.txt"; fi
+          safety check $REQS --json > safety.json || export SAFETY_FAILED=$?
+          # Fail if Safety found issues
+          if [ -n "$SAFETY_FAILED" ]; then
+            echo "Safety detected vulnerable dependencies" 1>&2
+            exit 1
+          fi
+
+      - name: Upload Safety report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: safety-report
+          path: safety.json
+          if-no-files-found: warn

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -124,6 +124,8 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         image-ref: cli-orchestrator:security-scan
+        severity: 'CRITICAL,HIGH'
+        exit-code: '1'
         format: 'sarif'
         output: 'trivy-results.sarif'
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,35 @@
+name: Security Scan
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # scan full history
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: .gitleaks.toml
+          # full history
+          args: "detect --log-opts=--all --report-format sarif --report-path gitleaks.sarif --redact"
+
+      - name: Upload gitleaks SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+title = "CLI_RESTART gitleaks configuration"
+
+[allowlist]
+description = "Allowlist for known false positives"
+files = [
+  "docs/.*",
+  "examples/.*",
+  "tests/fixtures/.*",
+]
+commits = []
+paths = []
+regexes = [
+  # UUIDs or generic hashes in docs
+  '''(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b''',
+]
+
+[rules]
+# Use built-in default rules from gitleaks
+

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# Add file path globs or regexes here to ignore specific findings
+# Example: ignore sample keys in example configs
+examples/config/*.json
+docs/**/*.md
+tests/fixtures/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,9 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# Ignore known/acceptable CVEs here (format: CVE-YYYY-NNNN or GHSA-...)
+# Example entries:
+# CVE-2023-12345
+# GHSA-xxxx-xxxx-xxxx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,21 @@ line_length = 88
 known_first_party = ["cli_multi_rapid"]
 skip_glob = ["*/migrations/*"]
 
+[tool.bandit]
+exclude_dirs = ["tests", ".venv", "venv", "build", "dist"]
+targets = ["src"]
+skips = []
+severity = "HIGH"
+confidence = "HIGH"
+
+# Optional: mypy configuration for pre-commit hook
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+disallow_untyped_defs = false
+
 [tool.ruff]
 target-version = "py39"
 line-length = 88


### PR DESCRIPTION
This PR hardens the CI pipeline with comprehensive security checks and quality gates.

Summary
- Add SAST (Bandit) and SCA (Safety) to CI (`ci.yml`)
- Add secrets scanning with Gitleaks scanning full history (`security-scan.yml`)
- Enforce container image scanning with Trivy failing on CRITICAL/HIGH (`docker-build.yml`)
- Expand pre-commit hooks with mypy; keep detect-secrets, ruff, black, isort
- Enforce Conventional Commits via `.githooks/commit-msg`
- Configure Dependabot for pip, GitHub Actions, and npm (VS Code extension) with grouped minor/patch updates

Details
- Bandit: scans `src`, excludes `tests`, outputs SARIF ? uploaded to Code Scanning
- Safety: checks `requirements.txt`, uploads `safety.json` artifact, fails build on vulnerabilities
- Gitleaks: scans full history with redact; customizable via `.gitleaks.toml` and `.gitleaksignore`
- Trivy: scans built production image; fails on CRITICAL/HIGH, uploads SARIF; `.trivyignore` available
- pyproject: adds `[tool.bandit]` config and baseline mypy options

Acceptance Criteria Mapping
- CI runs Bandit on Python code ? yes (security job)
- CI runs Safety dependency check ? yes (security job)
- Build fails on high/critical findings ? yes (Bandit at -lll, Trivy exit on CRITICAL/HIGH)
- Security scan results uploaded as artifacts ? Bandit SARIF + Safety JSON + Trivy SARIF
- Gitleaks runs on push/PR and fails on secrets ? yes; scans full history and uploads SARIF
- Dependabot configured for pip, actions, npm weekly ? yes, with grouped minor/patch updates
- Pre-commit includes yaml/json checks, ruff, black, isort, mypy, detect-secrets ? yes
- Commit-msg hook validates Conventional Commits ? yes (`.githooks/commit-msg`)

Test Plan
- Push to any branch/PR to trigger gitleaks and CI security workflow; verify:
  - Bandit job executes and uploads `bandit.sarif`
  - Safety job produces `safety.json` artifact
  - Trivy step fails if CRITICAL/HIGH CVEs are present
  - Gitleaks publishes `gitleaks.sarif` to Code Scanning
- Locally: `pre-commit install` then `pre-commit run --all-files`; set hooks path for commit-msg:
  - `git config core.hooksPath .githooks`

Notes
- Safety currently fails on any vulnerability; can be narrowed to high/critical upon request.
- Tune `.gitleaks.toml`/`.gitleaksignore` and `.trivyignore` as needed for accepted risks.