### PR TITLE
chore(executor): run git in repo root; auto-detect repo

### DIFF
--- a/WORKFLOW_VIS_FOLDER_1/ws-04-documentation-code-quality.json
+++ b/WORKFLOW_VIS_FOLDER_1/ws-04-documentation-code-quality.json
@@ -124,10 +124,10 @@
     "base_branch": "main",
     "auto_commit_and_push": false,
     "commands": [
-      "git -C C\\\\Users\\\\Richard Wilks\\\\CLI_RESTART fetch origin --prune",
-      "git -C C\\\\Users\\\\Richard Wilks\\\\CLI_RESTART switch main",
-      "git -C C\\\\Users\\\\Richard Wilks\\\\CLI_RESTART pull --ff-only",
-      "git -C C\\\\Users\\\\Richard Wilks\\\\CLI_RESTART status"
+      "git fetch origin --prune",
+      "git switch main",
+      "git pull --ff-only",
+      "git status"
     ],
     "commit_message_template": "docs: implement doc coverage tracking and standardize error messages\n\nAdd dead code detection with vulture, documentation coverage/freshness tracking,\nand standardized error codes with actionable messages.\n\nCloses: gap_CROSS_001, gap_CROSS_004, gap_CROSS_005\nWorkstream: WS-04"
   },


### PR DESCRIPTION
Executor improvements

- Add repo root auto-detection and use it for all subprocess cwd
- Remove hardcoded home path for git commands
- WS-04 JSON: revert to generic git commands (no hardcoded path)

Validation
- Dry-run WS-04 succeeded using generic commands
- This allows running from any working directory; optionally pass --workstreams-dir

No functional changes to orchestrator logic, only execution environment correctness.