### PR TITLE
Tools consolidation guard: policy + duplicate scan helper

### DIFF
--- a/tools/CONSOLIDATION.md
+++ b/tools/CONSOLIDATION.md
@@ -1,0 +1,14 @@
+Canonical script locations and duplication policy
+
+- Canonical atoms tooling lives under `tools/atomic-workflow-system/tools/atoms/`.
+  - Keep `md2atom.py`, `atom_validator.py`, and related converters here.
+  - Tests add this folder to `PYTHONPATH` and reference these modules.
+- Do not keep parallel copies of the same script at multiple paths.
+  - If a variant is needed, add flags or refactor into shared utilities.
+- Remove or merge any new duplicate files by content or by name.
+
+Enforcement
+
+- Virtual environments, caches, and tool logs are ignored via `.gitignore`.
+- Use the helper `tools/scripts/check_duplicates.ps1` to scan for duplicates before committing.
+

--- a/tools/scripts/check_duplicates.ps1
+++ b/tools/scripts/check_duplicates.ps1
@@ -1,0 +1,40 @@
+param(
+  [string]$Root = "tools"
+)
+
+Write-Host "Scanning for duplicate files under '$Root'..." -ForegroundColor Cyan
+
+$files = Get-ChildItem -LiteralPath $Root -Recurse -File -ErrorAction SilentlyContinue
+$entries = foreach ($f in $files) { 
+  $h = (Get-FileHash -Algorithm SHA256 -LiteralPath $f.FullName).Hash
+  [PSCustomObject]@{ Name=$f.Name; Path=$f.FullName; Hash=$h }
+}
+
+$dupeContent = $entries | Group-Object Hash | Where-Object { $_.Count -gt 1 }
+$dupeNames = $entries | Group-Object Name | Where-Object { $_.Count -gt 1 }
+
+if ($dupeContent) {
+  Write-Host "Duplicate content detected:" -ForegroundColor Yellow
+  foreach ($g in $dupeContent) {
+    Write-Host (" - HASH={0} COUNT={1}" -f $g.Name, $g.Count)
+    $g.Group | ForEach-Object { Write-Host ("    " + $_.Path) }
+  }
+} else {
+  Write-Host "No duplicate content found." -ForegroundColor Green
+}
+
+if ($dupeNames) {
+  Write-Host "\nFiles sharing the same name:" -ForegroundColor Yellow
+  foreach ($g in $dupeNames) {
+    $distinct = ($g.Group | Select-Object -ExpandProperty Hash | Sort-Object -Unique).Count
+    if ($distinct -gt 1) {
+      Write-Host (" - NAME='{0}' INSTANCES={1} DISTINCT={2}" -f $g.Name, $g.Count, $distinct)
+      $g.Group | ForEach-Object { Write-Host ("    " + $_.Path) }
+    }
+  }
+} else {
+  Write-Host "No same-named files across different paths." -ForegroundColor Green
+}
+
+Write-Host "\nDone." -ForegroundColor Cyan
+


### PR DESCRIPTION
This follow-up PR finalizes consolidation by:

- Documenting canonical script locations and duplication policy in tools/CONSOLIDATION.md
- Adding tools/scripts/check_duplicates.ps1 to quickly detect duplicate content and same-named files before committing

No code behavior changes.