### PR TITLE
docs: add gui functionality evaluation report

### DIFF
--- a/docs/gui_functionality_evaluation.md
+++ b/docs/gui_functionality_evaluation.md
@@ -1,0 +1,21 @@
+# GUI Functionality Evaluation
+
+date: 2025-10-23
+
+environment: ubuntu container (python 3.11)
+
+## Setup
+- Installed Python dependencies with `pip install PyQt6 psutil` (already satisfied).
+
+## Test Procedure
+1. Attempted to launch headless GUI test server (`python CLI_PY_GUI/gui/gui_test_server.py`).
+2. Planned to run parity regression harness (`python CLI_PY_GUI/gui/parity_test_harness.py`).
+
+## Results
+- Server startup failed immediately with `ImportError: libEGL.so.1: cannot open shared object file` when PyQt6 attempted to import Qt GUI modules.
+- Subsequent attempt with `QT_QPA_PLATFORM=minimal` produced the same missing `libEGL` error.
+- Without the server running, the parity harness could not connect and reported `[Errno 111] Connection refused` for every scenario.
+- Attempts to install `libEGL` through `apt-get update` were blocked by repository access restrictions (HTTP 403), preventing remediation inside this environment.
+
+## Conclusion
+The GUI could not be functionally evaluated because the PyQt6 runtime depends on `libEGL.so.1`, which is unavailable and cannot be installed due to restricted package repositories. All automated parity tests therefore failed at connection setup. Further evaluation requires installing the missing system library (e.g., `apt-get install -y libegl1`).


### PR DESCRIPTION
## Summary
- document the attempted Python CLI cockpit GUI parity evaluation
- capture the missing libEGL dependency and resulting connection failures when running the harness

## Testing
- `python CLI_PY_GUI/gui/parity_test_harness.py` *(fails: connection refused while server blocked by missing libEGL)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1d655dc0832f9eb1d5801a4c27b6